### PR TITLE
Update to cat nodes and shards requests to be plain text

### DIFF
--- a/lib/connection.go
+++ b/lib/connection.go
@@ -158,7 +158,13 @@ func (c *Conn) NewRequest(method, path, query string) (*Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Accept", "application/json")
+	
+	if path == "/_cat/shards" || path == "/_cat/nodes/" {
+		req.Header.Add("Accept", "text/plain")
+	} else {
+		req.Header.Add("Accept", "application/json")
+	}
+	
 	req.Header.Add("User-Agent", "elasticSearch/"+Version+" ("+runtime.GOOS+"-"+runtime.GOARCH+")")
 
 	if c.Username != "" || c.Password != "" {


### PR DESCRIPTION
With es5 if you make the Accept header "application/json" it will give back json for cat requests. In order to get GoMaintain working we force it to be "text/plain" for the endpoints it hits.